### PR TITLE
Added support for hidden SSID broadcast

### DIFF
--- a/RTL8720dn-Deauther.ino
+++ b/RTL8720dn-Deauther.ino
@@ -25,6 +25,9 @@ typedef struct {
 char *ssid = "RTL8720dn-Deauther";
 char *pass = "0123456789";
 
+// 1 = Hide SSID, 0 = Broadcast SSID
+int hidden = 1;
+
 int current_channel = 1;
 std::vector<WiFiScanResult> scan_results;
 std::map<int, std::vector<int>> deauth_channels;
@@ -327,7 +330,7 @@ void setup() {
   pinMode(LED_B, OUTPUT);
 
   DEBUG_SER_INIT();
-  WiFi.apbegin(ssid, pass, (char *)String(current_channel).c_str());
+  WiFi.apbegin(ssid, pass, (char *)String(current_channel).c_str(), hidden);
 
   scanNetworks();
 


### PR DESCRIPTION
Hi, 

I've seen it asked before, so I added this very simple flag to control the broadcasting of the AP's SSID, to be hidden or to broadcast it normally.

However, with its current implementation, this requires manually setting the flag in the source code and recompiling the firmware, if the user wants to change the SSID broadcast behavior. 

Perhaps we could expose it as a toggleable option on the web server, and write it to a configuration file?

I can dig into this when I have a bit more time.

