### PR TITLE
Fix: Resolve compilation errors

### DIFF
--- a/RTL8720dn-Deauther.ino
+++ b/RTL8720dn-Deauther.ino
@@ -1,3 +1,4 @@
+#undef max
 #include "vector"
 #include "wifi_conf.h"
 #include "map"
@@ -8,6 +9,9 @@
 #include "WiFi.h"
 #include "WiFiServer.h"
 #include "WiFiClient.h"
+
+void handleRoot(WiFiClient &client);
+void handle404(WiFiClient &client);
 
 // LEDs:
 //  Red: System usable, Web server active etc.


### PR DESCRIPTION
This commit addresses two separate compilation issues:

1.  **Undeclared Functions:** Adds forward declarations for the `handleRoot` and `handle404` functions to resolve a "not declared in this scope" error. These functions were being called in `loop()` before their definitions appeared.

2.  **Macro Conflict:** Adds `#undef max` before including the `<vector>` and `<map>` headers. This prevents a conflict between the `max` macro defined in the Arduino core headers and the `std::max` function used by the C++ standard library.